### PR TITLE
Fix memory leak on freeing threads

### DIFF
--- a/jobs.odin
+++ b/jobs.odin
@@ -24,8 +24,6 @@ package jobs
 
 import "base:intrinsics"
 import "base:runtime"
-import "core:log"
-import "core:math"
 import "core:sync"
 
 MAIN_THREAD_INDEX :: 0
@@ -339,6 +337,9 @@ shutdown :: proc() {
     _state.running = false
     if len(_state.threads) > 0 {
         _wait_for_threads_to_finish(_state.threads[:])
+    }
+    for thread in _state.threads {
+        free(thread)
     }
     delete(_state.threads, _state.allocator)
 }

--- a/jobs.odin
+++ b/jobs.odin
@@ -254,7 +254,7 @@ run_worker_thread :: proc() {
     }
 }
 
-// Warning: 
+// Warning:
 default_thread_proc :: proc(_: rawptr) {
     for is_running() {
         try_execute_queued_job()
@@ -337,9 +337,7 @@ shutdown :: proc() {
     _state.running = false
     if len(_state.threads) > 0 {
         _wait_for_threads_to_finish(_state.threads[:])
-    }
-    for thread in _state.threads {
-        free(thread)
+        _destroy_threads(_state.threads[:])
     }
     delete(_state.threads, _state.allocator)
 }

--- a/jobs_generic.odin
+++ b/jobs_generic.odin
@@ -1,6 +1,7 @@
+#+build linux, darwin
 // Generic platform backend using 'core:' libs
 
-#+build linux, darwin
+
 package jobs
 
 import "core:os"
@@ -22,4 +23,10 @@ _current_thread_id :: proc() -> u64 {
 
 _wait_for_threads_to_finish :: proc(threads: []Thread) {
     thread.join_multiple(..threads)
+}
+
+_destroy_threads :: proc(threads: []Thread) {
+    for thread in threads {
+        free(thread)
+    }
 }

--- a/jobs_windows.odin
+++ b/jobs_windows.odin
@@ -68,3 +68,9 @@ _wait_for_threads_to_finish :: proc(threads: []Thread) {
         panic("Failed to wait for threads to finish.")
     }
 }
+
+_destroy_threads :: proc(threads: []Thread) {
+    for thread in threads {
+        windows.CloseHandle(thread)
+    }
+}


### PR DESCRIPTION
Hey Jakub, 

Thanks for this library, it's been great!
I know you mentioned you have a WIP rewrite of this, but I fixed a memory leak in this V1 implementation, and figured I'd PR it upstream anyway. 

Fix: The threads themselves are pointers, so they need to be individually freed along with the dynamic array being deleted.

Cheers!